### PR TITLE
Fix linting sprintf that uses "%[1]s"

### DIFF
--- a/analyzer/testdata/src/p/p.go
+++ b/analyzer/testdata/src/p/p.go
@@ -23,8 +23,9 @@ func positive() {
 	fmt.Sprint(s)              // want "fmt.Sprint can be replaced with just using the string"
 	fmt.Errorf("hello")        // want "fmt.Errorf can be replaced with errors.New"
 
-	fmt.Sprintf("Hello %s", s)      // want "fmt.Sprintf can be replaced with string addition"
-	fmt.Sprintf("%s says Hello", s) // want "fmt.Sprintf can be replaced with string addition"
+	fmt.Sprintf("Hello %s", s)         // want "fmt.Sprintf can be replaced with string addition"
+	fmt.Sprintf("%s says Hello", s)    // want "fmt.Sprintf can be replaced with string addition"
+	fmt.Sprintf("Hello says %[1]s", s) // want "fmt.Sprintf can be replaced with string addition"
 
 	var err error
 	fmt.Sprintf("%s", errSentinel) // want "fmt.Sprintf can be replaced with errSentinel.Error()"
@@ -209,6 +210,7 @@ func negative() {
 	fmt.Sprintf("%3d", 42)
 	fmt.Sprintf("% d", 42)
 	fmt.Sprintf("%-10d", 42)
+	fmt.Sprintf("%s %[1]s", "hello")
 	fmt.Sprintf("%[2]d %[1]d\n", 11, 22)
 	fmt.Sprintf("%[3]*.[2]*[1]f", 12.0, 2, 6)
 	fmt.Sprintf("%d %d %#[1]x %#x", 16, 17)

--- a/analyzer/testdata/src/p/p.go.golden
+++ b/analyzer/testdata/src/p/p.go.golden
@@ -27,6 +27,7 @@ func positive() {
 
 	"Hello " + s      // want "fmt.Sprintf can be replaced with string addition"
 	s + " says Hello" // want "fmt.Sprintf can be replaced with string addition"
+	"Hello says " + s // want "fmt.Sprintf can be replaced with string addition"
 
 	var err error
 	errSentinel.Error() // want "fmt.Sprintf can be replaced with errSentinel.Error()"
@@ -211,6 +212,7 @@ func negative() {
 	fmt.Sprintf("%3d", 42)
 	fmt.Sprintf("% d", 42)
 	fmt.Sprintf("%-10d", 42)
+	fmt.Sprintf("%s %[1]s", "hello")
 	fmt.Sprintf("%[2]d %[1]d\n", 11, 22)
 	fmt.Sprintf("%[3]*.[2]*[1]f", 12.0, 2, 6)
 	fmt.Sprintf("%d %d %#[1]x %#x", 16, 17)


### PR DESCRIPTION
Noticed when running "--fix" against a codebase that made use of "%[1]s" and "%s" format directives.

Without the fixes the negative test incorrectly tries to concatenate:
```
        -       fmt.Sprintf("%s %[1]s", "hello")
        +       "hello" + " %[1]s"
```
and the positive test doesn't:
```
        -       "Hello says " + s // want "fmt.Sprintf can be replaced with string addition"
        +       fmt.Sprintf("Hello says %[1]s", s) // want "fmt.Sprintf can be replaced with string addition"
```