### PR TITLE
docs: update installation instructions to use go install

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Golang linter for performance, aiming at usages of `fmt.Sprintf` which have fast
 ## Installation
 
 ```sh
-go get github.com/catenacyber/perfsprint@latest
+go install github.com/catenacyber/perfsprint@latest
 ```
 
 ## Usage


### PR DESCRIPTION
Updated the installation instructions in the README to use 'go install' instead of 'go get' for installing the 'perfsprint' linter. 'go get' is no longer recommended for installing binaries, and 'go install' should be used for Go version 1.17+.