### PR TITLE
analyzer: fix int-conversion scope

### DIFF
--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -338,7 +338,7 @@ func (n *perfSprint) run(pass *analysis.Pass) (interface{}, error) {
 					},
 				},
 			}
-		case isBasicType(valueType, types.Int) && oneOf(verb, "%v", "%d"):
+		case isBasicType(valueType, types.Int) && oneOf(verb, "%v", "%d") && n.intConv:
 			fname := pass.Fset.File(call.Pos()).Name()
 			removedFmtUsages[fname]++
 			_, ok := neededPackages[fname]
@@ -361,7 +361,7 @@ func (n *perfSprint) run(pass *analysis.Pass) (interface{}, error) {
 					},
 				},
 			}
-		case isBasicType(valueType, types.Int64) && oneOf(verb, "%v", "%d"):
+		case isBasicType(valueType, types.Int64) && oneOf(verb, "%v", "%d") && n.intConv:
 			fname := pass.Fset.File(call.Pos()).Name()
 			removedFmtUsages[fname]++
 			_, ok := neededPackages[fname]
@@ -426,7 +426,7 @@ func (n *perfSprint) run(pass *analysis.Pass) (interface{}, error) {
 					},
 				},
 			}
-		case isBasicType(valueType, types.Uint64) && oneOf(verb, "%v", "%d", "%x"):
+		case isBasicType(valueType, types.Uint64) && oneOf(verb, "%v", "%d", "%x") && n.intConv:
 			base := []byte(", 10")
 			if verb == "%x" {
 				base = []byte(", 16")

--- a/analyzer/testdata/src/noconv/p.go
+++ b/analyzer/testdata/src/noconv/p.go
@@ -2,7 +2,7 @@ package noconv
 
 import (
 	"errors"
-	"fmt" // want "Fix imports"
+	"fmt"
 	"os"
 )
 
@@ -14,12 +14,12 @@ func positive() {
 	var i16 int16
 	var i32 int32
 	var i64 int64
-	fmt.Sprintf("%d", i)  // want "fmt.Sprintf can be replaced with faster strconv.Itoa"
-	fmt.Sprintf("%v", i)  // want "fmt.Sprintf can be replaced with faster strconv.Itoa"
-	fmt.Sprint(i)         // want "fmt.Sprint can be replaced with faster strconv.Itoa"
-	fmt.Sprintf("%d", 42) // want "fmt.Sprintf can be replaced with faster strconv.Itoa"
-	fmt.Sprintf("%v", 42) // want "fmt.Sprintf can be replaced with faster strconv.Itoa"
-	fmt.Sprint(42)        // want "fmt.Sprint can be replaced with faster strconv.Itoa"
+	fmt.Sprintf("%d", i)
+	fmt.Sprintf("%v", i)
+	fmt.Sprint(i)
+	fmt.Sprintf("%d", 42)
+	fmt.Sprintf("%v", 42)
+	fmt.Sprint(42)
 	fmt.Sprintf("%d", i8)
 	fmt.Sprintf("%v", i8)
 	fmt.Sprint(i8)
@@ -38,12 +38,12 @@ func positive() {
 	fmt.Sprintf("%d", int32(42))
 	fmt.Sprintf("%v", int32(42))
 	fmt.Sprint(int32(42))
-	fmt.Sprintf("%d", i64)       // want "fmt.Sprintf can be replaced with faster strconv.FormatInt"
-	fmt.Sprintf("%v", i64)       // want "fmt.Sprintf can be replaced with faster strconv.FormatInt"
-	fmt.Sprint(i64)              // want "fmt.Sprint can be replaced with faster strconv.FormatInt"
-	fmt.Sprintf("%d", int64(42)) // want "fmt.Sprintf can be replaced with faster strconv.FormatInt"
-	fmt.Sprintf("%v", int64(42)) // want "fmt.Sprintf can be replaced with faster strconv.FormatInt"
-	fmt.Sprint(int64(42))        // want "fmt.Sprint can be replaced with faster strconv.FormatInt"
+	fmt.Sprintf("%d", i64)
+	fmt.Sprintf("%v", i64)
+	fmt.Sprint(i64)
+	fmt.Sprintf("%d", int64(42))
+	fmt.Sprintf("%v", int64(42))
+	fmt.Sprint(int64(42))
 
 	var ui uint
 	var ui8 uint8
@@ -74,12 +74,12 @@ func positive() {
 	fmt.Sprintf("%d", uint32(42))
 	fmt.Sprintf("%v", uint32(42))
 	fmt.Sprint(uint32(42))
-	fmt.Sprintf("%d", ui64)       // want "fmt.Sprintf can be replaced with faster strconv.FormatUint"
-	fmt.Sprintf("%v", ui64)       // want "fmt.Sprintf can be replaced with faster strconv.FormatUint"
-	fmt.Sprint(ui64)              // want "fmt.Sprint can be replaced with faster strconv.FormatUint"
-	fmt.Sprintf("%d", uint64(42)) // want "fmt.Sprintf can be replaced with faster strconv.FormatUint"
-	fmt.Sprintf("%v", uint64(42)) // want "fmt.Sprintf can be replaced with faster strconv.FormatUint"
-	fmt.Sprint(uint64(42))        // want "fmt.Sprint can be replaced with faster strconv.FormatUint"
+	fmt.Sprintf("%d", ui64)
+	fmt.Sprintf("%v", ui64)
+	fmt.Sprint(ui64)
+	fmt.Sprintf("%d", uint64(42))
+	fmt.Sprintf("%v", uint64(42))
+	fmt.Sprint(uint64(42))
 }
 
 func negative() {

--- a/analyzer/testdata/src/noconv/p.go.golden
+++ b/analyzer/testdata/src/noconv/p.go.golden
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strconv" // want "Fix imports"
+	"strconv"
 )
 
 var errSentinel = errors.New("connection refused")
@@ -15,12 +15,12 @@ func positive() {
 	var i16 int16
 	var i32 int32
 	var i64 int64
-	strconv.Itoa(i)  // want "fmt.Sprintf can be replaced with faster strconv.Itoa"
-	strconv.Itoa(i)  // want "fmt.Sprintf can be replaced with faster strconv.Itoa"
-	strconv.Itoa(i)  // want "fmt.Sprint can be replaced with faster strconv.Itoa"
-	strconv.Itoa(42) // want "fmt.Sprintf can be replaced with faster strconv.Itoa"
-	strconv.Itoa(42) // want "fmt.Sprintf can be replaced with faster strconv.Itoa"
-	strconv.Itoa(42) // want "fmt.Sprint can be replaced with faster strconv.Itoa"
+	fmt.Sprintf("%d", i)
+	fmt.Sprintf("%v", i)
+	fmt.Sprint(i)
+	fmt.Sprintf("%d", 42)
+	fmt.Sprintf("%v", 42)
+	fmt.Sprint(42)
 	fmt.Sprintf("%d", i8)
 	fmt.Sprintf("%v", i8)
 	fmt.Sprint(i8)
@@ -39,12 +39,12 @@ func positive() {
 	fmt.Sprintf("%d", int32(42))
 	fmt.Sprintf("%v", int32(42))
 	fmt.Sprint(int32(42))
-	strconv.FormatInt(i64, 10)       // want "fmt.Sprintf can be replaced with faster strconv.FormatInt"
-	strconv.FormatInt(i64, 10)       // want "fmt.Sprintf can be replaced with faster strconv.FormatInt"
-	strconv.FormatInt(i64, 10)       // want "fmt.Sprint can be replaced with faster strconv.FormatInt"
-	strconv.FormatInt(int64(42), 10) // want "fmt.Sprintf can be replaced with faster strconv.FormatInt"
-	strconv.FormatInt(int64(42), 10) // want "fmt.Sprintf can be replaced with faster strconv.FormatInt"
-	strconv.FormatInt(int64(42), 10) // want "fmt.Sprint can be replaced with faster strconv.FormatInt"
+	fmt.Sprintf("%d", i64)
+	fmt.Sprintf("%v", i64)
+	fmt.Sprint(i64)
+	fmt.Sprintf("%d", int64(42))
+	fmt.Sprintf("%v", int64(42))
+	fmt.Sprint(int64(42))
 
 	var ui uint
 	var ui8 uint8


### PR DESCRIPTION
intConv parameter was introduced to disable some rules.

The code was introduced with e958370, but only a part of the rules
related to integer conversions were altered.

This commit completes what was done in the previous commit
