### PR TITLE
ci: update actions and golangci-lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,24 +11,16 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GO_VERSION: '1.20'
-      GOLANGCI_LINT_VERSION: v1.54.2
+      GOLANGCI_LINT_VERSION: v1.62.0
       CGO_ENABLED: 0
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Set up Go ${{ env.GO_VERSION }}
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ^${{ env.GO_VERSION }}
-
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Cache Go modules
-        uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
 
       - name: Check and get dependencies
         run: |
@@ -40,4 +32,6 @@ jobs:
         run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin ${GOLANGCI_LINT_VERSION}
 
       - name: Make
-        run: make
+        run: |
+          make
+          git diff --exit-code


### PR DESCRIPTION
This fixes [failing CI](https://github.com/catenacyber/perfsprint/actions/runs/11487265512/job/31971435910).

Changes:

- update versions for `actions/checkout`, `actions/setup-go`
- remove unneeded `actions/cache` because `actions/setup-go` has caching
- update golangci-lint to the latest v1.62.0, it's compatible with Go 1.23
- add `git diff --exit-code` after `make` because `go fmt ./...` may change files, and we should detect this and fail pipeline