### PR TITLE
clean up ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Check and get dependencies
         run: |
-          make tidy
+          go mod tidy
           git diff --exit-code go.mod
           git diff --exit-code go.sum
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,14 +24,16 @@ jobs:
 
       - name: Check and get dependencies
         run: |
-          go mod tidy
+          make tidy
           git diff --exit-code go.mod
           git diff --exit-code go.sum
 
-      - name: Install golangci-lint ${{ env.GOLANGCI_LINT_VERSION }}
-        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin ${GOLANGCI_LINT_VERSION}
+      - name: Run golangci-lint ${{ env.GOLANGCI_LINT_VERSION }}
+        uses: golangci/golangci-lint-action@v6
+        with:
+          args: --verbose
+          version: ${{ env.GOLANGCI_LINT_VERSION }}
 
-      - name: Make
-        run: |
-          make
-          git diff --exit-code
+      - run: make test
+
+      - run: make install

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,3 @@
+linters:
+  enable:
+    - gofmt


### PR DESCRIPTION
### Description

This PR clean up the ci workflow
It uses GitHub action instead of manual install for golangci lint and use it to define the golangci lint version used.

It uses setup go option to read from go.mod file the golang version instead of environment variable 

It uses explicitly the make targets that are uses in the workflow