### PR TITLE
fix: refactor unit tests so they don't depend on previous tests

### DIFF
--- a/analyzer/testdata/src/int-conversion/p.go.golden
+++ b/analyzer/testdata/src/int-conversion/p.go.golden
@@ -1,26 +1,75 @@
-package noconv
+package p
 
 import (
+	"encoding/hex" // want "Fix imports"
 	"errors"
 	"fmt"
+	"io"
+	"log"
+	"net/url"
 	"os"
-	"strconv" // want "Fix imports"
+	"strconv"
+	"time"
 )
 
 var errSentinel = errors.New("connection refused")
 
 func positive() {
+	var s string
+	"hello"             // want "fmt.Sprintf can be replaced with just using the string"
+	"hello"             // want "fmt.Sprintf can be replaced with just using the string"
+	"hello"             // want "fmt.Sprintf can be replaced with just using the string"
+	"hello"             // want "fmt.Sprint can be replaced with just using the string"
+	s                   // want "fmt.Sprintf can be replaced with just using the string"
+	s                   // want "fmt.Sprintf can be replaced with just using the string"
+	s                   // want "fmt.Sprintf can be replaced with just using the string"
+	s                   // want "fmt.Sprint can be replaced with just using the string"
+	errors.New("hello") // want "fmt.Errorf can be replaced with errors.New"
+
+	"Hello " + s      // want "fmt.Sprintf can be replaced with string concatenation"
+	s + " says Hello" // want "fmt.Sprintf can be replaced with string concatenation"
+	"Hello says " + s // want "fmt.Sprintf can be replaced with string concatenation"
+
+	var err error
+	fmt.Sprintf("%s", errSentinel)
+	fmt.Sprintf("%v", errSentinel)
+	fmt.Sprint(errSentinel)
+	fmt.Sprintf("%s", io.EOF)
+	fmt.Sprintf("%v", io.EOF)
+	fmt.Sprint(io.EOF)
+	fmt.Sprintf("%s", err)
+	fmt.Sprintf("%v", err)
+	fmt.Sprint(err)
+
+	var b bool
+	strconv.FormatBool(true)  // want "fmt.Sprintf can be replaced with faster strconv.FormatBool"
+	strconv.FormatBool(true)  // want "fmt.Sprintf can be replaced with faster strconv.FormatBool"
+	strconv.FormatBool(true)  // want "fmt.Sprint can be replaced with faster strconv.FormatBool"
+	strconv.FormatBool(false) // want "fmt.Sprintf can be replaced with faster strconv.FormatBool"
+	strconv.FormatBool(false) // want "fmt.Sprintf can be replaced with faster strconv.FormatBool"
+	strconv.FormatBool(false) // want "fmt.Sprint can be replaced with faster strconv.FormatBool"
+	strconv.FormatBool(b)     // want "fmt.Sprintf can be replaced with faster strconv.FormatBool"
+	strconv.FormatBool(b)     // want "fmt.Sprintf can be replaced with faster strconv.FormatBool"
+	strconv.FormatBool(b)     // want "fmt.Sprint can be replaced with faster strconv.FormatBool"
+
+	var bs []byte
+	var ba [3]byte
+	hex.EncodeToString([]byte{'a'})  // want "fmt.Sprintf can be replaced with faster hex.EncodeToString"
+	hex.EncodeToString([]uint8{'b'}) // want "fmt.Sprintf can be replaced with faster hex.EncodeToString"
+	hex.EncodeToString(bs)           // want "fmt.Sprintf can be replaced with faster hex.EncodeToString"
+	hex.EncodeToString(ba[:])        // want "fmt.Sprintf can be replaced with faster hex.EncodeToString"
+
 	var i int
 	var i8 int8
 	var i16 int16
 	var i32 int32
 	var i64 int64
-	strconv.Itoa(i)  // want "fmt.Sprintf can be replaced with faster strconv.Itoa"
-	strconv.Itoa(i)  // want "fmt.Sprintf can be replaced with faster strconv.Itoa"
-	strconv.Itoa(i)  // want "fmt.Sprint can be replaced with faster strconv.Itoa"
-	strconv.Itoa(42) // want "fmt.Sprintf can be replaced with faster strconv.Itoa"
-	strconv.Itoa(42) // want "fmt.Sprintf can be replaced with faster strconv.Itoa"
-	strconv.Itoa(42) // want "fmt.Sprint can be replaced with faster strconv.Itoa"
+	strconv.Itoa(i)                  // want "fmt.Sprintf can be replaced with faster strconv.Itoa"
+	strconv.Itoa(i)                  // want "fmt.Sprintf can be replaced with faster strconv.Itoa"
+	strconv.Itoa(i)                  // want "fmt.Sprint can be replaced with faster strconv.Itoa"
+	strconv.Itoa(42)                 // want "fmt.Sprintf can be replaced with faster strconv.Itoa"
+	strconv.Itoa(42)                 // want "fmt.Sprintf can be replaced with faster strconv.Itoa"
+	strconv.Itoa(42)                 // want "fmt.Sprint can be replaced with faster strconv.Itoa"
 	fmt.Sprintf("%d", i8)
 	fmt.Sprintf("%v", i8)
 	fmt.Sprint(i8)
@@ -75,12 +124,59 @@ func positive() {
 	fmt.Sprintf("%d", uint32(42))
 	fmt.Sprintf("%v", uint32(42))
 	fmt.Sprint(uint32(42))
-	strconv.FormatUint(ui64, 10)       // want "fmt.Sprintf can be replaced with faster strconv.FormatUint"
-	strconv.FormatUint(ui64, 10)       // want "fmt.Sprintf can be replaced with faster strconv.FormatUint"
-	strconv.FormatUint(ui64, 10)       // want "fmt.Sprint can be replaced with faster strconv.FormatUint"
-	strconv.FormatUint(uint64(42), 10) // want "fmt.Sprintf can be replaced with faster strconv.FormatUint"
-	strconv.FormatUint(uint64(42), 10) // want "fmt.Sprintf can be replaced with faster strconv.FormatUint"
-	strconv.FormatUint(uint64(42), 10) // want "fmt.Sprint can be replaced with faster strconv.FormatUint"
+	strconv.FormatUint(ui64, 10)               // want "fmt.Sprintf can be replaced with faster strconv.FormatUint"
+	strconv.FormatUint(ui64, 10)               // want "fmt.Sprintf can be replaced with faster strconv.FormatUint"
+	strconv.FormatUint(ui64, 16)               // want "fmt.Sprintf can be replaced with faster strconv.FormatUint"
+	fmt.Sprintf("%x", uint(42))
+	strconv.FormatUint(ui64, 10)               // want "fmt.Sprint can be replaced with faster strconv.FormatUint"
+	strconv.FormatUint(uint64(42), 10)         // want "fmt.Sprintf can be replaced with faster strconv.FormatUint"
+	strconv.FormatUint(uint64(42), 10)         // want "fmt.Sprintf can be replaced with faster strconv.FormatUint"
+	strconv.FormatUint(uint64(42), 10)         // want "fmt.Sprint can be replaced with faster strconv.FormatUint"
+}
+
+func suggestedFixesTest() {
+	_ = func() string {
+		if false {
+			return "replace me" // want "fmt.Sprint can be replaced with just using the string"
+		}
+		return "replace me" // want "fmt.Sprintf can be replaced with just using the string"
+	}
+
+	fmt.Println(fmt.Sprint(errSentinel))
+	fmt.Println(fmt.Sprintf("%s", errSentinel))
+
+	_ = func() string {
+		switch 42 {
+		case 1:
+			return strconv.FormatBool(false) // want "fmt.Sprint can be replaced with faster strconv.FormatBool"
+		case 2:
+			return strconv.FormatBool(true) // want "fmt.Sprintf can be replaced with faster strconv.FormatBool"
+		}
+		return ""
+	}
+
+	var offset int
+	params := url.Values{}
+	params.Set("offset", strconv.Itoa(offset))
+	params.Set("offset", strconv.Itoa(offset))
+
+	var pubKey []byte
+	if verifyPubKey := true; verifyPubKey {
+		log.Println("pubkey=" + hex.EncodeToString(pubKey)) // want "fmt.Sprintf can be replaced with faster hex.EncodeToString"
+	}
+
+	var metaHash [16]byte
+	fn := fmt.Sprintf("%s.%x", "coverage.MetaFilePref", metaHash)
+	_ = "tmp." + fn + strconv.FormatInt(time.Now().UnixNano(), 10) // want "fmt.Sprintf can be replaced with faster strconv.FormatInt"
+	_ = "tmp." + fn + strconv.FormatInt(time.Now().UnixNano(), 10) // want "fmt.Sprint can be replaced with faster strconv.FormatInt"
+
+	var change struct{ User struct{ ID uint } }
+	var userStr string
+	if id := change.User.ID; id != 0 {
+		userStr = fmt.Sprintf("%d", id)
+		userStr = fmt.Sprint(id)
+	}
+	_ = userStr
 }
 
 func negative() {
@@ -95,6 +191,7 @@ func negative() {
 	fmt.Printf("%v")
 	fmt.Printf("%d", 42)
 	fmt.Printf("%s %d", "hello", 42)
+	fmt.Errorf("this is %s", "complex")
 
 	fmt.Fprint(os.Stdout, "%d", 42)
 	fmt.Fprintf(os.Stdout, "test")
@@ -116,6 +213,8 @@ func negative() {
 	fmt.Sprintf("%3d", 42)
 	fmt.Sprintf("% d", 42)
 	fmt.Sprintf("%-10d", 42)
+	fmt.Sprintf("%s %[1]s", "hello")
+	fmt.Sprintf("%[1]s %[1]s", "hello")
 	fmt.Sprintf("%[2]d %[1]d\n", 11, 22)
 	fmt.Sprintf("%[3]*.[2]*[1]f", 12.0, 2, 6)
 	fmt.Sprintf("%d %d %#[1]x %#x", 16, 17)

--- a/analyzer/testdata/src/integer-format/p.go
+++ b/analyzer/testdata/src/integer-format/p.go
@@ -68,24 +68,24 @@ func positive() {
 	fmt.Sprintf("%d", 42)
 	fmt.Sprintf("%v", 42)
 	fmt.Sprint(42)
-	fmt.Sprintf("%d", i8)        // want "fmt.Sprintf can be replaced with faster strconv.Itoa"
-	fmt.Sprintf("%v", i8)        // want "fmt.Sprintf can be replaced with faster strconv.Itoa"
-	fmt.Sprint(i8)               // want "fmt.Sprint can be replaced with faster strconv.Itoa"
-	fmt.Sprintf("%d", int8(42))  // want "fmt.Sprintf can be replaced with faster strconv.Itoa"
-	fmt.Sprintf("%v", int8(42))  // want "fmt.Sprintf can be replaced with faster strconv.Itoa"
-	fmt.Sprint(int8(42))         // want "fmt.Sprint can be replaced with faster strconv.Itoa"
-	fmt.Sprintf("%d", i16)       // want "fmt.Sprintf can be replaced with faster strconv.Itoa"
-	fmt.Sprintf("%v", i16)       // want "fmt.Sprintf can be replaced with faster strconv.Itoa"
-	fmt.Sprint(i16)              // want "fmt.Sprint can be replaced with faster strconv.Itoa"
-	fmt.Sprintf("%d", int16(42)) // want "fmt.Sprintf can be replaced with faster strconv.Itoa"
-	fmt.Sprintf("%v", int16(42)) // want "fmt.Sprintf can be replaced with faster strconv.Itoa"
-	fmt.Sprint(int16(42))        // want "fmt.Sprint can be replaced with faster strconv.Itoa"
-	fmt.Sprintf("%d", i32)       // want "fmt.Sprintf can be replaced with faster strconv.Itoa"
-	fmt.Sprintf("%v", i32)       // want "fmt.Sprintf can be replaced with faster strconv.Itoa"
-	fmt.Sprint(i32)              // want "fmt.Sprint can be replaced with faster strconv.Itoa"
-	fmt.Sprintf("%d", int32(42)) // want "fmt.Sprintf can be replaced with faster strconv.Itoa"
-	fmt.Sprintf("%v", int32(42)) // want "fmt.Sprintf can be replaced with faster strconv.Itoa"
-	fmt.Sprint(int32(42))        // want "fmt.Sprint can be replaced with faster strconv.Itoa"
+	fmt.Sprintf("%d", i8)
+	fmt.Sprintf("%v", i8)
+	fmt.Sprint(i8)
+	fmt.Sprintf("%d", int8(42))
+	fmt.Sprintf("%v", int8(42))
+	fmt.Sprint(int8(42))
+	fmt.Sprintf("%d", i16)
+	fmt.Sprintf("%v", i16)
+	fmt.Sprint(i16)
+	fmt.Sprintf("%d", int16(42))
+	fmt.Sprintf("%v", int16(42))
+	fmt.Sprint(int16(42))
+	fmt.Sprintf("%d", i32)
+	fmt.Sprintf("%v", i32)
+	fmt.Sprint(i32)
+	fmt.Sprintf("%d", int32(42))
+	fmt.Sprintf("%v", int32(42))
+	fmt.Sprint(int32(42))
 	fmt.Sprintf("%d", i64)
 	fmt.Sprintf("%v", i64)
 	fmt.Sprint(i64)
@@ -98,34 +98,34 @@ func positive() {
 	var ui16 uint16
 	var ui32 uint32
 	var ui64 uint64
-	fmt.Sprintf("%d", ui)         // want "fmt.Sprintf can be replaced with faster strconv.FormatUint"
-	fmt.Sprintf("%v", ui)         // want "fmt.Sprintf can be replaced with faster strconv.FormatUint"
-	fmt.Sprint(ui)                // want "fmt.Sprint can be replaced with faster strconv.FormatUint"
-	fmt.Sprintf("%d", uint(42))   // want "fmt.Sprintf can be replaced with faster strconv.FormatUint"
-	fmt.Sprintf("%v", uint(42))   // want "fmt.Sprintf can be replaced with faster strconv.FormatUint"
-	fmt.Sprint(uint(42))          // want "fmt.Sprint can be replaced with faster strconv.FormatUint"
-	fmt.Sprintf("%d", ui8)        // want "fmt.Sprintf can be replaced with faster strconv.FormatUint"
-	fmt.Sprintf("%v", ui8)        // want "fmt.Sprintf can be replaced with faster strconv.FormatUint"
-	fmt.Sprint(ui8)               // want "fmt.Sprint can be replaced with faster strconv.FormatUint"
-	fmt.Sprintf("%d", uint8(42))  // want "fmt.Sprintf can be replaced with faster strconv.FormatUint"
-	fmt.Sprintf("%v", uint8(42))  // want "fmt.Sprintf can be replaced with faster strconv.FormatUint"
-	fmt.Sprint(uint8(42))         // want "fmt.Sprint can be replaced with faster strconv.FormatUint"
-	fmt.Sprintf("%d", ui16)       // want "fmt.Sprintf can be replaced with faster strconv.FormatUint"
-	fmt.Sprintf("%v", ui16)       // want "fmt.Sprintf can be replaced with faster strconv.FormatUint"
-	fmt.Sprint(ui16)              // want "fmt.Sprint can be replaced with faster strconv.FormatUint"
-	fmt.Sprintf("%d", uint16(42)) // want "fmt.Sprintf can be replaced with faster strconv.FormatUint"
-	fmt.Sprintf("%v", uint16(42)) // want "fmt.Sprintf can be replaced with faster strconv.FormatUint"
-	fmt.Sprint(uint16(42))        // want "fmt.Sprint can be replaced with faster strconv.FormatUint"
-	fmt.Sprintf("%d", ui32)       // want "fmt.Sprintf can be replaced with faster strconv.FormatUint"
-	fmt.Sprintf("%v", ui32)       // want "fmt.Sprintf can be replaced with faster strconv.FormatUint"
-	fmt.Sprint(ui32)              // want "fmt.Sprint can be replaced with faster strconv.FormatUint"
-	fmt.Sprintf("%d", uint32(42)) // want "fmt.Sprintf can be replaced with faster strconv.FormatUint"
-	fmt.Sprintf("%v", uint32(42)) // want "fmt.Sprintf can be replaced with faster strconv.FormatUint"
-	fmt.Sprint(uint32(42))        // want "fmt.Sprint can be replaced with faster strconv.FormatUint"
+	fmt.Sprintf("%d", ui)
+	fmt.Sprintf("%v", ui)
+	fmt.Sprint(ui)
+	fmt.Sprintf("%d", uint(42))
+	fmt.Sprintf("%v", uint(42))
+	fmt.Sprint(uint(42))
+	fmt.Sprintf("%d", ui8)
+	fmt.Sprintf("%v", ui8)
+	fmt.Sprint(ui8)
+	fmt.Sprintf("%d", uint8(42))
+	fmt.Sprintf("%v", uint8(42))
+	fmt.Sprint(uint8(42))
+	fmt.Sprintf("%d", ui16)
+	fmt.Sprintf("%v", ui16)
+	fmt.Sprint(ui16)
+	fmt.Sprintf("%d", uint16(42))
+	fmt.Sprintf("%v", uint16(42))
+	fmt.Sprint(uint16(42))
+	fmt.Sprintf("%d", ui32)
+	fmt.Sprintf("%v", ui32)
+	fmt.Sprint(ui32)
+	fmt.Sprintf("%d", uint32(42))
+	fmt.Sprintf("%v", uint32(42))
+	fmt.Sprint(uint32(42))
 	fmt.Sprintf("%d", ui64)
 	fmt.Sprintf("%v", ui64)
 	fmt.Sprintf("%x", ui64)
-	fmt.Sprintf("%x", uint(42)) // want "fmt.Sprintf can be replaced with faster strconv.FormatUint"
+	fmt.Sprintf("%x", uint(42))
 	fmt.Sprint(ui64)
 	fmt.Sprintf("%d", uint64(42))
 	fmt.Sprintf("%v", uint64(42))
@@ -171,8 +171,8 @@ func suggestedFixesTest() {
 	var change struct{ User struct{ ID uint } }
 	var userStr string
 	if id := change.User.ID; id != 0 {
-		userStr = fmt.Sprintf("%d", id) // want "fmt.Sprintf can be replaced with faster strconv.FormatUint"
-		userStr = fmt.Sprint(id)        // want "fmt.Sprint can be replaced with faster strconv.FormatUint"
+		userStr = fmt.Sprintf("%d", id)
+		userStr = fmt.Sprint(id)
 	}
 	_ = userStr
 }

--- a/analyzer/testdata/src/integer-format/p.go.golden
+++ b/analyzer/testdata/src/integer-format/p.go.golden
@@ -70,24 +70,24 @@ func positive() {
 	fmt.Sprintf("%d", 42)
 	fmt.Sprintf("%v", 42)
 	fmt.Sprint(42)
-	strconv.Itoa(int(i8))        // want "fmt.Sprintf can be replaced with faster strconv.Itoa"
-	strconv.Itoa(int(i8))        // want "fmt.Sprintf can be replaced with faster strconv.Itoa"
-	strconv.Itoa(int(i8))        // want "fmt.Sprint can be replaced with faster strconv.Itoa"
-	strconv.Itoa(int(int8(42)))  // want "fmt.Sprintf can be replaced with faster strconv.Itoa"
-	strconv.Itoa(int(int8(42)))  // want "fmt.Sprintf can be replaced with faster strconv.Itoa"
-	strconv.Itoa(int(int8(42)))  // want "fmt.Sprint can be replaced with faster strconv.Itoa"
-	strconv.Itoa(int(i16))       // want "fmt.Sprintf can be replaced with faster strconv.Itoa"
-	strconv.Itoa(int(i16))       // want "fmt.Sprintf can be replaced with faster strconv.Itoa"
-	strconv.Itoa(int(i16))       // want "fmt.Sprint can be replaced with faster strconv.Itoa"
-	strconv.Itoa(int(int16(42))) // want "fmt.Sprintf can be replaced with faster strconv.Itoa"
-	strconv.Itoa(int(int16(42))) // want "fmt.Sprintf can be replaced with faster strconv.Itoa"
-	strconv.Itoa(int(int16(42))) // want "fmt.Sprint can be replaced with faster strconv.Itoa"
-	strconv.Itoa(int(i32))       // want "fmt.Sprintf can be replaced with faster strconv.Itoa"
-	strconv.Itoa(int(i32))       // want "fmt.Sprintf can be replaced with faster strconv.Itoa"
-	strconv.Itoa(int(i32))       // want "fmt.Sprint can be replaced with faster strconv.Itoa"
-	strconv.Itoa(int(int32(42))) // want "fmt.Sprintf can be replaced with faster strconv.Itoa"
-	strconv.Itoa(int(int32(42))) // want "fmt.Sprintf can be replaced with faster strconv.Itoa"
-	strconv.Itoa(int(int32(42))) // want "fmt.Sprint can be replaced with faster strconv.Itoa"
+	fmt.Sprintf("%d", i8)
+	fmt.Sprintf("%v", i8)
+	fmt.Sprint(i8)
+	fmt.Sprintf("%d", int8(42))
+	fmt.Sprintf("%v", int8(42))
+	fmt.Sprint(int8(42))
+	fmt.Sprintf("%d", i16)
+	fmt.Sprintf("%v", i16)
+	fmt.Sprint(i16)
+	fmt.Sprintf("%d", int16(42))
+	fmt.Sprintf("%v", int16(42))
+	fmt.Sprint(int16(42))
+	fmt.Sprintf("%d", i32)
+	fmt.Sprintf("%v", i32)
+	fmt.Sprint(i32)
+	fmt.Sprintf("%d", int32(42))
+	fmt.Sprintf("%v", int32(42))
+	fmt.Sprint(int32(42))
 	fmt.Sprintf("%d", i64)
 	fmt.Sprintf("%v", i64)
 	fmt.Sprint(i64)
@@ -100,34 +100,34 @@ func positive() {
 	var ui16 uint16
 	var ui32 uint32
 	var ui64 uint64
-	strconv.FormatUint(uint64(ui), 10)         // want "fmt.Sprintf can be replaced with faster strconv.FormatUint"
-	strconv.FormatUint(uint64(ui), 10)         // want "fmt.Sprintf can be replaced with faster strconv.FormatUint"
-	strconv.FormatUint(uint64(ui), 10)         // want "fmt.Sprint can be replaced with faster strconv.FormatUint"
-	strconv.FormatUint(uint64(uint(42)), 10)   // want "fmt.Sprintf can be replaced with faster strconv.FormatUint"
-	strconv.FormatUint(uint64(uint(42)), 10)   // want "fmt.Sprintf can be replaced with faster strconv.FormatUint"
-	strconv.FormatUint(uint64(uint(42)), 10)   // want "fmt.Sprint can be replaced with faster strconv.FormatUint"
-	strconv.FormatUint(uint64(ui8), 10)        // want "fmt.Sprintf can be replaced with faster strconv.FormatUint"
-	strconv.FormatUint(uint64(ui8), 10)        // want "fmt.Sprintf can be replaced with faster strconv.FormatUint"
-	strconv.FormatUint(uint64(ui8), 10)        // want "fmt.Sprint can be replaced with faster strconv.FormatUint"
-	strconv.FormatUint(uint64(uint8(42)), 10)  // want "fmt.Sprintf can be replaced with faster strconv.FormatUint"
-	strconv.FormatUint(uint64(uint8(42)), 10)  // want "fmt.Sprintf can be replaced with faster strconv.FormatUint"
-	strconv.FormatUint(uint64(uint8(42)), 10)  // want "fmt.Sprint can be replaced with faster strconv.FormatUint"
-	strconv.FormatUint(uint64(ui16), 10)       // want "fmt.Sprintf can be replaced with faster strconv.FormatUint"
-	strconv.FormatUint(uint64(ui16), 10)       // want "fmt.Sprintf can be replaced with faster strconv.FormatUint"
-	strconv.FormatUint(uint64(ui16), 10)       // want "fmt.Sprint can be replaced with faster strconv.FormatUint"
-	strconv.FormatUint(uint64(uint16(42)), 10) // want "fmt.Sprintf can be replaced with faster strconv.FormatUint"
-	strconv.FormatUint(uint64(uint16(42)), 10) // want "fmt.Sprintf can be replaced with faster strconv.FormatUint"
-	strconv.FormatUint(uint64(uint16(42)), 10) // want "fmt.Sprint can be replaced with faster strconv.FormatUint"
-	strconv.FormatUint(uint64(ui32), 10)       // want "fmt.Sprintf can be replaced with faster strconv.FormatUint"
-	strconv.FormatUint(uint64(ui32), 10)       // want "fmt.Sprintf can be replaced with faster strconv.FormatUint"
-	strconv.FormatUint(uint64(ui32), 10)       // want "fmt.Sprint can be replaced with faster strconv.FormatUint"
-	strconv.FormatUint(uint64(uint32(42)), 10) // want "fmt.Sprintf can be replaced with faster strconv.FormatUint"
-	strconv.FormatUint(uint64(uint32(42)), 10) // want "fmt.Sprintf can be replaced with faster strconv.FormatUint"
-	strconv.FormatUint(uint64(uint32(42)), 10) // want "fmt.Sprint can be replaced with faster strconv.FormatUint"
+	fmt.Sprintf("%d", ui)
+	fmt.Sprintf("%v", ui)
+	fmt.Sprint(ui)
+	fmt.Sprintf("%d", uint(42))
+	fmt.Sprintf("%v", uint(42))
+	fmt.Sprint(uint(42))
+	fmt.Sprintf("%d", ui8)
+	fmt.Sprintf("%v", ui8)
+	fmt.Sprint(ui8)
+	fmt.Sprintf("%d", uint8(42))
+	fmt.Sprintf("%v", uint8(42))
+	fmt.Sprint(uint8(42))
+	fmt.Sprintf("%d", ui16)
+	fmt.Sprintf("%v", ui16)
+	fmt.Sprint(ui16)
+	fmt.Sprintf("%d", uint16(42))
+	fmt.Sprintf("%v", uint16(42))
+	fmt.Sprint(uint16(42))
+	fmt.Sprintf("%d", ui32)
+	fmt.Sprintf("%v", ui32)
+	fmt.Sprint(ui32)
+	fmt.Sprintf("%d", uint32(42))
+	fmt.Sprintf("%v", uint32(42))
+	fmt.Sprint(uint32(42))
 	fmt.Sprintf("%d", ui64)
 	fmt.Sprintf("%v", ui64)
 	fmt.Sprintf("%x", ui64)
-	strconv.FormatUint(uint64(uint(42)), 16) // want "fmt.Sprintf can be replaced with faster strconv.FormatUint"
+	fmt.Sprintf("%x", uint(42))
 	fmt.Sprint(ui64)
 	fmt.Sprintf("%d", uint64(42))
 	fmt.Sprintf("%v", uint64(42))
@@ -173,8 +173,8 @@ func suggestedFixesTest() {
 	var change struct{ User struct{ ID uint } }
 	var userStr string
 	if id := change.User.ID; id != 0 {
-		userStr = strconv.FormatUint(uint64(id), 10) // want "fmt.Sprintf can be replaced with faster strconv.FormatUint"
-		userStr = strconv.FormatUint(uint64(id), 10) // want "fmt.Sprint can be replaced with faster strconv.FormatUint"
+		userStr = fmt.Sprintf("%d", id)
+		userStr = fmt.Sprint(id)
 	}
 	_ = userStr
 }

--- a/analyzer/testdata/src/sprint1/p.go
+++ b/analyzer/testdata/src/sprint1/p.go
@@ -29,15 +29,15 @@ func positive() {
 	fmt.Sprintf("Hello says %[1]s", s) // want "fmt.Sprintf can be replaced with string concatenation"
 
 	var err error
-	fmt.Sprintf("%s", errSentinel) // want "fmt.Sprintf can be replaced with errSentinel.Error()"
-	fmt.Sprintf("%v", errSentinel) // want "fmt.Sprintf can be replaced with errSentinel.Error()"
-	fmt.Sprint(errSentinel)        // want "fmt.Sprint can be replaced with errSentinel.Error()"
-	fmt.Sprintf("%s", io.EOF)      // want "fmt.Sprintf can be replaced with io.EOF.Error()"
-	fmt.Sprintf("%v", io.EOF)      // want "fmt.Sprintf can be replaced with io.EOF.Error()"
-	fmt.Sprint(io.EOF)             // want "fmt.Sprint can be replaced with io.EOF.Error()"
-	fmt.Sprintf("%s", err)         // want "fmt.Sprintf can be replaced with err.Error()"
-	fmt.Sprintf("%v", err)         // want "fmt.Sprintf can be replaced with err.Error()"
-	fmt.Sprint(err)                // want "fmt.Sprint can be replaced with err.Error()"
+	fmt.Sprintf("%s", errSentinel)
+	fmt.Sprintf("%v", errSentinel)
+	fmt.Sprint(errSentinel)
+	fmt.Sprintf("%s", io.EOF)
+	fmt.Sprintf("%v", io.EOF)
+	fmt.Sprint(io.EOF)
+	fmt.Sprintf("%s", err)
+	fmt.Sprintf("%v", err)
+	fmt.Sprint(err)
 
 	var b bool
 	fmt.Sprintf("%t", true)  // want "fmt.Sprintf can be replaced with faster strconv.FormatBool"
@@ -140,8 +140,8 @@ func suggestedFixesTest() {
 		return fmt.Sprintf("%s", "replace me") // want "fmt.Sprintf can be replaced with just using the string"
 	}
 
-	fmt.Println(fmt.Sprint(errSentinel))        // want "fmt.Sprint can be replaced with errSentinel.Error()"
-	fmt.Println(fmt.Sprintf("%s", errSentinel)) // want "fmt.Sprintf can be replaced with errSentinel.Error()"
+	fmt.Println(fmt.Sprint(errSentinel))
+	fmt.Println(fmt.Sprintf("%s", errSentinel))
 
 	_ = func() string {
 		switch 42 {

--- a/analyzer/testdata/src/sprint1/p.go.golden
+++ b/analyzer/testdata/src/sprint1/p.go.golden
@@ -31,15 +31,15 @@ func positive() {
 	"Hello says " + s // want "fmt.Sprintf can be replaced with string concatenation"
 
 	var err error
-	errSentinel.Error() // want "fmt.Sprintf can be replaced with errSentinel.Error()"
-	errSentinel.Error() // want "fmt.Sprintf can be replaced with errSentinel.Error()"
-	errSentinel.Error() // want "fmt.Sprint can be replaced with errSentinel.Error()"
-	io.EOF.Error()      // want "fmt.Sprintf can be replaced with io.EOF.Error()"
-	io.EOF.Error()      // want "fmt.Sprintf can be replaced with io.EOF.Error()"
-	io.EOF.Error()      // want "fmt.Sprint can be replaced with io.EOF.Error()"
-	err.Error()         // want "fmt.Sprintf can be replaced with err.Error()"
-	err.Error()         // want "fmt.Sprintf can be replaced with err.Error()"
-	err.Error()         // want "fmt.Sprint can be replaced with err.Error()"
+	fmt.Sprintf("%s", errSentinel)
+	fmt.Sprintf("%v", errSentinel)
+	fmt.Sprint(errSentinel)
+	fmt.Sprintf("%s", io.EOF)
+	fmt.Sprintf("%v", io.EOF)
+	fmt.Sprint(io.EOF)
+	fmt.Sprintf("%s", err)
+	fmt.Sprintf("%v", err)
+	fmt.Sprint(err)
 
 	var b bool
 	strconv.FormatBool(true)  // want "fmt.Sprintf can be replaced with faster strconv.FormatBool"
@@ -142,8 +142,8 @@ func suggestedFixesTest() {
 		return "replace me" // want "fmt.Sprintf can be replaced with just using the string"
 	}
 
-	fmt.Println(errSentinel.Error()) // want "fmt.Sprint can be replaced with errSentinel.Error()"
-	fmt.Println(errSentinel.Error()) // want "fmt.Sprintf can be replaced with errSentinel.Error()"
+	fmt.Println(fmt.Sprint(errSentinel))
+	fmt.Println(fmt.Sprintf("%s", errSentinel))
 
 	_ = func() string {
 		switch 42 {


### PR DESCRIPTION
The fact a flag can deactivate some other flags must be done after the flags are overloaded in unit tests.

This PR fixes the unit tests and updates the golden files.
