### PR TITLE
feat: improve diagnostic

### DIFF
--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -58,6 +58,7 @@ func New() *analysis.Analyzer {
 	n := newPerfSprint()
 	r := &analysis.Analyzer{
 		Name:     "perfsprint",
+		URL:      "https://github.com/catenacyber/perfsprint",
 		Doc:      "Checks that fmt.Sprintf can be replaced with a faster alternative.",
 		Run:      n.run,
 		Requires: []*analysis.Analyzer{inspect.Analyzer},

--- a/analyzer/diagnostic.go
+++ b/analyzer/diagnostic.go
@@ -10,16 +10,15 @@ func newAnalysisDiagnostic(
 	message string,
 	suggestedFixes []analysis.SuggestedFix,
 ) *analysis.Diagnostic {
-	d := analysis.Diagnostic{
+	if checker != "" {
+		message = checker + ": " + message
+	}
+
+	return &analysis.Diagnostic{
 		Pos:            analysisRange.Pos(),
 		End:            analysisRange.End(),
 		SuggestedFixes: suggestedFixes,
+		Message:        message,
+		Category:       checker, // Possible hashtag available on the documentation
 	}
-	if checker != "" {
-		d.Category = checker
-		d.Message = checker + ": " + message
-	} else {
-		d.Message = message
-	}
-	return &d
 }


### PR DESCRIPTION
An absolute URL is now provided in the diagnostic message.

The Category field helps to classify the diagnostic message in the documentation.

https://pkg.go.dev/golang.org/x/tools/go/analysis#Diagnostic

The Readme file is not yet updated to add these html anchors.
