### PR TITLE
fix: bump x/tools to 0.30.0 to support Go 1.24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,18 +9,21 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: ['1.22', 'stable', 'oldstable']
     env:
-      GO_VERSION: '1.20'
-      GOLANGCI_LINT_VERSION: v1.62.0
+      GOLANGCI_LINT_VERSION: v1.64.5
       CGO_ENABLED: 0
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Go ${{ env.GO_VERSION }}
+      - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ^${{ env.GO_VERSION }}
+          go-version: ${{ matrix.go }}
+          check-latest: true
 
       - name: Check and get dependencies
         run: |

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,12 @@
 module github.com/catenacyber/perfsprint
 
-go 1.20
+go 1.22.0
 
-require golang.org/x/tools v0.14.0
+toolchain go1.23.0
+
+require golang.org/x/tools v0.30.0
 
 require (
-	golang.org/x/mod v0.13.0 // indirect
-	golang.org/x/sys v0.13.0 // indirect
+	golang.org/x/mod v0.23.0 // indirect
+	golang.org/x/sync v0.11.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,8 @@
-golang.org/x/mod v0.13.0 h1:I/DsJXRlw/8l/0c24sM9yb0T4z9liZTduXvdAWYiysY=
-golang.org/x/mod v0.13.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
-golang.org/x/sync v0.4.0 h1:zxkM55ReGkDlKSM+Fu41A+zmbZuaPVbGMzvvdUPznYQ=
-golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
-golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/tools v0.14.0 h1:jvNa2pY0M4r62jkRQ6RwEZZyPcymeL9XZMLBbV7U2nc=
-golang.org/x/tools v0.14.0/go.mod h1:uYBEerGOWcJyEORxN+Ek8+TT266gXkNlHdJBwexUsBg=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+golang.org/x/mod v0.23.0 h1:Zb7khfcRGKk+kqfxFaP5tZqCnDZMjC5VtUBs87Hr6QM=
+golang.org/x/mod v0.23.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
+golang.org/x/sync v0.11.0 h1:GGz8+XQP4FvTTrjZPzNKTMFtSXH80RAzG+5ghFPgK9w=
+golang.org/x/sync v0.11.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/tools v0.30.0 h1:BgcpHewrV5AUp2G9MebG4XPFI1E2W41zU1SaqVA9vJY=
+golang.org/x/tools v0.30.0/go.mod h1:c347cR/OJfw5TI+GfX7RUPNMdDRRbjvYTS0jPyvsVtY=


### PR DESCRIPTION
This PR fixes `perfsprint` to work with Go 1.24.

### How to reproduce

Build `perfsprint` with Go 1.24, run and get "internal error".

```sh
$ go version
go version go1.24.0 darwin/arm64

$ go build -o perfsprint main.go
```

#### Expected

```sh
$ ./perfsprint ./...
/Users/Oleksandr_Redko/src/github.com/catenacyber/perfsprint/analyzer/analyzer_test.go:60:12: fmt.Sprintf can be replaced with just using the string
/Users/Oleksandr_Redko/src/github.com/catenacyber/perfsprint/analyzer/analyzer_test.go:61:12: fmt.Sprintf can be replaced with just using the string
/Users/Oleksandr_Redko/src/github.com/catenacyber/perfsprint/analyzer/analyzer_test.go:62:12: fmt.Sprint can be replaced with just using the string
...
```

#### Actual

```sh
$ ./perfsprint ./...
perfsprint: internal error: package "bytes" without types was imported from "github.com/catenacyber/perfsprint/analyzer"
```