### PR TITLE
minor improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,16 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.22', 'stable', 'oldstable']
+        go: ['stable', 'oldstable']
     env:
-      GOLANGCI_LINT_VERSION: v1.64.5
-      CGO_ENABLED: 0
+      GOLANGCI_LINT_VERSION: v2.5.0
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go }}
           check-latest: true
@@ -32,7 +31,7 @@ jobs:
           git diff --exit-code go.sum
 
       - name: Run golangci-lint ${{ env.GOLANGCI_LINT_VERSION }}
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
           args: --verbose
           version: ${{ env.GOLANGCI_LINT_VERSION }}

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,3 +1,23 @@
+version: "2"
+run:
+  allow-parallel-runners: true
 linters:
+  enable:
+    - errcheck
+    - gosec
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+  exclusions:
+    rules:
+      - linters:
+          - staticcheck
+        path: '(.+)_test\.go'
+  settings:
+    staticcheck:
+      checks:
+        - "all"
+formatters:
   enable:
     - gofmt

--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,14 @@ tidy:
 	go mod tidy
 
 lint:
-	golangci-lint run
+	golangci-lint run --fix -v -c .golangci.yaml ./...
 
 test:
-	go test ./...
+	go test -race ./...
 
 bench:
-	go test -bench=Bench ./...
+	# each benchmark runs for 5 seconds, in a single CPU (to make results more consistent); report memory allocation
+	go test -bench=Bench ./... -benchtime 5s -cpu 1 -benchmem
 
 install:
 	go install .

--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -1,3 +1,4 @@
+// Package analyzer provides a static analysis tool that checks that fmt.Sprintf can be replaced with a faster alternative.
 package analyzer
 
 import (
@@ -105,7 +106,7 @@ func isConcatable(verb string) bool {
 	if strings.Count(verb, "%[1]s") > 1 {
 		return false
 	}
-	return (hasPrefix || hasSuffix) && !(hasPrefix && hasSuffix)
+	return (hasPrefix || hasSuffix) && !(hasPrefix && hasSuffix) //nolint:staticcheck
 }
 
 func (n *perfSprint) run(pass *analysis.Pass) (interface{}, error) {

--- a/analyzer/replacements_bench_test.go
+++ b/analyzer/replacements_bench_test.go
@@ -15,21 +15,18 @@ func BenchmarkStringFormatting(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			_ = fmt.Sprint("hello") //nolint:gosimple //https://staticcheck.io/docs/checks#S1039
 		}
-		b.ReportAllocs()
 	})
 
 	b.Run("fmt.Sprintf", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			_ = fmt.Sprintf("%s", "hello") //nolint:gosimple //https://staticcheck.io/docs/checks#S1025
 		}
-		b.ReportAllocs()
 	})
 
 	b.Run("just string", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			_ = "hello"
 		}
-		b.ReportAllocs()
 	})
 }
 
@@ -38,21 +35,18 @@ func BenchmarkErrorFormatting(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			_ = fmt.Sprint(context.DeadlineExceeded)
 		}
-		b.ReportAllocs()
 	})
 
 	b.Run("fmt.Sprintf", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			_ = fmt.Sprintf("%s", context.DeadlineExceeded)
 		}
-		b.ReportAllocs()
 	})
 
 	b.Run("Error()", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			_ = context.DeadlineExceeded.Error()
 		}
-		b.ReportAllocs()
 	})
 }
 
@@ -61,14 +55,12 @@ func BenchmarkFormattingError(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			_ = fmt.Errorf("onlystring")
 		}
-		b.ReportAllocs()
 	})
 
 	b.Run("errors.New", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			_ = errors.New("onlystring")
 		}
-		b.ReportAllocs()
 	})
 }
 
@@ -77,21 +69,18 @@ func BenchmarkBoolFormatting(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			_ = fmt.Sprint(true)
 		}
-		b.ReportAllocs()
 	})
 
 	b.Run("fmt.Sprintf", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			_ = fmt.Sprintf("%t", true)
 		}
-		b.ReportAllocs()
 	})
 
 	b.Run("strconv.FormatBool", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			_ = strconv.FormatBool(true)
 		}
-		b.ReportAllocs()
 	})
 }
 
@@ -100,14 +89,12 @@ func BenchmarkHexEncoding(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			_ = fmt.Sprintf("%x", []byte{'a', 'b', 'c'})
 		}
-		b.ReportAllocs()
 	})
 
 	b.Run("hex.EncodeToString", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			_ = hex.EncodeToString([]byte{'a', 'b', 'c'})
 		}
-		b.ReportAllocs()
 	})
 }
 
@@ -117,7 +104,6 @@ func BenchmarkHexArrayEncoding(b *testing.B) {
 			val := [3]byte{'a', 'b', 'c'}
 			_ = fmt.Sprintf("%x", val)
 		}
-		b.ReportAllocs()
 	})
 
 	b.Run("hex.EncodeToString", func(b *testing.B) {
@@ -125,7 +111,6 @@ func BenchmarkHexArrayEncoding(b *testing.B) {
 			val := [3]byte{'a', 'b', 'c'}
 			_ = hex.EncodeToString(val[:])
 		}
-		b.ReportAllocs()
 	})
 }
 
@@ -134,21 +119,18 @@ func BenchmarkIntFormatting(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			_ = fmt.Sprint(math.MaxInt)
 		}
-		b.ReportAllocs()
 	})
 
 	b.Run("fmt.Sprintf", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			_ = fmt.Sprintf("%d", math.MaxInt)
 		}
-		b.ReportAllocs()
 	})
 
 	b.Run("strconv.Itoa", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			_ = strconv.Itoa(math.MaxInt)
 		}
-		b.ReportAllocs()
 	})
 }
 
@@ -158,7 +140,6 @@ func BenchmarkIntConversionFormatting(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			_ = fmt.Sprint(u)
 		}
-		b.ReportAllocs()
 	})
 
 	b.Run("fmt.Sprintf", func(b *testing.B) {
@@ -166,7 +147,6 @@ func BenchmarkIntConversionFormatting(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			_ = fmt.Sprintf("%d", u)
 		}
-		b.ReportAllocs()
 	})
 
 	b.Run("strconv.FormatInt", func(b *testing.B) {
@@ -174,7 +154,6 @@ func BenchmarkIntConversionFormatting(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			_ = strconv.FormatInt(int64(u), 10)
 		}
-		b.ReportAllocs()
 	})
 }
 
@@ -183,21 +162,18 @@ func BenchmarkUintFormatting(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			_ = fmt.Sprint(uint64(math.MaxUint))
 		}
-		b.ReportAllocs()
 	})
 
 	b.Run("fmt.Sprintf", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			_ = fmt.Sprintf("%d", uint64(math.MaxUint))
 		}
-		b.ReportAllocs()
 	})
 
 	b.Run("strconv.FormatUint", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			_ = strconv.FormatUint(math.MaxUint, 10)
 		}
-		b.ReportAllocs()
 	})
 }
 
@@ -206,14 +182,12 @@ func BenchmarkUintHexFormatting(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			_ = fmt.Sprintf("%x", uint64(math.MaxUint))
 		}
-		b.ReportAllocs()
 	})
 
 	b.Run("strconv.FormatUint", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			_ = strconv.FormatUint(math.MaxUint, 16)
 		}
-		b.ReportAllocs()
 	})
 }
 
@@ -222,13 +196,11 @@ func BenchmarkStringAdditionFormatting(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			_ = fmt.Sprintf("Hello %s", "world")
 		}
-		b.ReportAllocs()
 	})
 
 	b.Run("string concatenation", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			_ = "Hello " + "world"
 		}
-		b.ReportAllocs()
 	})
 }


### PR DESCRIPTION
Changes:
- Update to linter v2
- Update versions of github actions
- Run `staticcheck` linters (except in tests)
- In benchmarks, replace `b.ReportAllocs()` with `-benchmem`